### PR TITLE
NoFallDamage area flag implementation

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -1,6 +1,6 @@
 name: Festival
 author: Genboy
-version: 1.0.7.1-dev
+version: 1.0.8
 main: genboy\Festival\Main
 load: POSTWORLD
 api: [3.0.0-ALPHA10,3.0.0-ALPHA11,3.0.0-ALPHA12,3.0.0]

--- a/resources/config.yml
+++ b/resources/config.yml
@@ -50,7 +50,10 @@ Default:
 
   # Keep players from executing area event commands without specific perms
   Perms: false
-
+  
+  # Keep players from taking fall damage
+  NoFallDamage: false
+  
 # Settings for unprotected areas in individual worlds:
 Worlds:
  
@@ -92,6 +95,9 @@ Worlds:
     # Keep players from executing area event commands without specific perms
     Perms: false
 
+    # Keep players from taking fall damage
+    NoFallDamage: false
+	
   world:
   
     # Keep players from getting hurt? 
@@ -129,3 +135,6 @@ Worlds:
 
     # Keep players from executing area event commands without specific perms
     Perms: false
+
+    # Keep players from taking fall damage
+    NoFallDamage: false

--- a/src/genboy/Festival/Main.php
+++ b/src/genboy/Festival/Main.php
@@ -61,6 +61,8 @@ class Main extends PluginBase implements Listener{
 	private $hunger = false;
 	/** @var bool */
 	private $perms = false;
+	/** @var bool */
+	private $nofalldamage = false;
 
 	/** @var bool[] */
 	private $selectingFirst = [];
@@ -149,7 +151,10 @@ class Main extends PluginBase implements Listener{
 				$flags["hunger"] = false;
 				$newchange['Hunger'] = "! Area Hunger flag missing, now updated to 'false'; please see /resources/config.yml";
 			}
-
+			if( !isset($datum["flags"]["nofalldamage"]) ){
+				$flags["nofalldamage"] = false;
+				$newchange['NoFallDamage'] = "! Area NoFallDamage flag missing, now updated to 'false'; please see /resources/config.yml";
+			}
 			new Area($datum["name"], $datum["desc"], $flags, new Vector3($datum["pos1"]["0"], $datum["pos1"]["1"], $datum["pos1"]["2"]), new Vector3($datum["pos2"]["0"], $datum["pos2"]["1"], $datum["pos2"]["2"]), $datum["level"], $datum["whitelist"], $datum["commands"], $datum["events"], $this);
 		}
 
@@ -225,8 +230,9 @@ class Main extends PluginBase implements Listener{
 		if(!isset($c["Default"]["Hunger"])) {
 			$c["Default"]["Hunger"] = false;
 		}
-
-
+		if(!isset($c["Default"]["NoFallDamage"])) {
+			$c["Default"]["NoFallDamage"] = false;
+		}
 
 		$this->god = $c["Default"]["God"];
 		$this->edit = $c["Default"]["Edit"];
@@ -246,7 +252,7 @@ class Main extends PluginBase implements Listener{
 		// new in v1.0.7
 		$this->tnt = $c["Default"]["TNT"];
 		$this->tnt = $c["Default"]["Hunger"];
-
+		$this->nofalldamage = $c["Default"]["NoFallDamage"];
         
         // world default flag settings
 		if(is_array( $c["Worlds"] )){
@@ -286,6 +292,9 @@ class Main extends PluginBase implements Listener{
 				}
 				if( !isset($flags["Hunger"]) ){
 					$flags["Hunger"] = $this->hunger;
+				}
+				if( !isset($flags["NoFallDamage"]) ){
+					$flags["NoFallDamage"] = $this->nofalldamage;
 				}
 				$this->levels[$level] = $flags;
 			}
@@ -330,7 +339,8 @@ class Main extends PluginBase implements Listener{
             "drop",
             "msg","message",
             "passage","pass","barrier",
-            "perms","perm"
+            "perms","perm",
+			"nofalldamage"
         ];
         $str = strtolower( $str );
         $flag = false;
@@ -369,6 +379,9 @@ class Main extends PluginBase implements Listener{
             if( $str == "hunger" || $str == "starve" ){
                 $flag = "hunger";
             }
+			if( $str == "nofalldamage" ){
+				$flag = "nofalldamage";
+			}
         }
         return $flag;
     }
@@ -639,6 +652,7 @@ class Main extends PluginBase implements Listener{
 			case "tnt":
 			case "explode":
 			case "drop":
+			case "nofalldamage";
 				if($sender->hasPermission("festival") || $sender->hasPermission("festival.command") || $sender->hasPermission("festival.command.fe") || $sender->hasPermission("festival.command.fe.flag")){
 					if(isset($args[1])){
                         
@@ -729,10 +743,10 @@ class Main extends PluginBase implements Listener{
 										}
 										$o = TextFormat::GREEN . "Flag " . $flag . " set to " . $status . " for area " . $area->getName() . "!";
 									}else{
-										$o = TextFormat::RED . "Flag not found. (Flags: edit, god, pvp, flight, touch, effects, msg, passage, perms, drop)";
+										$o = TextFormat::RED . "Flag not found. (Flags: edit, god, pvp, flight, touch, effects, msg, passage, perms, drop, nofalldamage)";
 									}
 								}else{
-									$o = TextFormat::RED . "Please specify a flag. (Flags: edit, god, pvp, flight, touch, effects, msg, passage, perms, drop)";
+									$o = TextFormat::RED . "Please specify a flag. (Flags: edit, god, pvp, flight, touch, effects, msg, passage, perms, drop, nofalldamage)";
 								}
 							}
 						}else{
@@ -1122,7 +1136,34 @@ class Main extends PluginBase implements Listener{
 	public function onHurt(EntityDamageEvent $event) : void{
 		$this->canDamage( $event );
 	}
-
+	/** On No fall Damage
+	 * @param EntityDamageEvent $event
+	 * @ignoreCancelled true
+	 */
+	/**
+	 * @param Entity $entity
+	 *
+	 * @return bool
+	 */
+	public function nfdamage(Entity $entity) : bool{
+		$o = true;
+		$default = (isset($this->levels[$entity->getLevel()->getName()]) ? $this->levels[$entity->getLevel()->getName()]["NoFallDamage"] : $this->nofalldamage);
+		if($default){
+			$o = false;
+		}
+		foreach($this->areas as $area){
+			if($area->contains(new Vector3($entity->getX(), $entity->getY(), $entity->getZ()), $entity->getLevel()->getName())){
+				if($default && !$area->getFlag("nofalldamage")){
+					$o = true;
+					break;
+				}
+				if($area->getFlag("nofalldamage")){
+					$o = false;
+				}
+			}
+		}
+		return $o;
+	}
 	/** On Damage
 	 * @param EntityDamageEvent $event
 	 * @ignoreCancelled true
@@ -1953,7 +1994,20 @@ class Main extends PluginBase implements Listener{
 		return $l;
 
 	}
-
+	public function onFallDisable(EntityDamageEvent $event) : void{
+		$player = $event->getEntity();
+    	$level = $player->getLevel()->getFolderName();
+		$cause = $event->getCause();
+		if($event->getEntity() instanceof Player){
+			if(!$this->canGetHurt($player)){
+				$event->setCancelled();
+			}
+			
+			if($cause == EntityDamageEvent::CAUSE_FALL && !$this->nfdamage($player)){
+				$event->setCancelled(true);
+			}
+		}
+	}
 
 	/** Save areas
 	 * @var obj area
@@ -1966,7 +2020,6 @@ class Main extends PluginBase implements Listener{
 		}
 		file_put_contents($this->getDataFolder() . "areas.json", json_encode($areas));
 	}
-
     /**  Festival Console Sign Flag for developers
      *   makes it easy to find Festival console output fast
      */

--- a/src/genboy/Festival/Main.php
+++ b/src/genboy/Festival/Main.php
@@ -151,6 +151,7 @@ class Main extends PluginBase implements Listener{
 				$flags["hunger"] = false;
 				$newchange['Hunger'] = "! Area Hunger flag missing, now updated to 'false'; please see /resources/config.yml";
 			}
+			//new in v1.0.8
 			if( !isset($datum["flags"]["nofalldamage"]) ){
 				$flags["nofalldamage"] = false;
 				$newchange['NoFallDamage'] = "! Area NoFallDamage flag missing, now updated to 'false'; please see /resources/config.yml";
@@ -230,6 +231,7 @@ class Main extends PluginBase implements Listener{
 		if(!isset($c["Default"]["Hunger"])) {
 			$c["Default"]["Hunger"] = false;
 		}
+		// new in v1.0.8
 		if(!isset($c["Default"]["NoFallDamage"])) {
 			$c["Default"]["NoFallDamage"] = false;
 		}
@@ -252,6 +254,7 @@ class Main extends PluginBase implements Listener{
 		// new in v1.0.7
 		$this->tnt = $c["Default"]["TNT"];
 		$this->tnt = $c["Default"]["Hunger"];
+		// new in v1.0.8
 		$this->nofalldamage = $c["Default"]["NoFallDamage"];
         
         // world default flag settings
@@ -293,6 +296,7 @@ class Main extends PluginBase implements Listener{
 				if( !isset($flags["Hunger"]) ){
 					$flags["Hunger"] = $this->hunger;
 				}
+				// new in v1.0.8
 				if( !isset($flags["NoFallDamage"]) ){
 					$flags["NoFallDamage"] = $this->nofalldamage;
 				}


### PR DESCRIPTION
So, I've been testing this plugin. It's all well, but has some problems, such as: God disables PvP and No Fall Damage. And I thought "Why not create a new flag called NoFallDamage for No Fall Damage only, and have PvP enabled at the same time"? So I created the flag, and has been tested, and all is well. No bugs, no nothing. This flag is meant to be specifically for Fall damage disabler in that area. Not sure why this wasn't implemented by itself so people could have the option to enable the no fall damage flag, but also have PvP enabled at the same time. but here it is;
This PR also includes: Implementations to No Fall Damage flag with / without PvP enabled, and a version bump - making it so it works as it should, and a new version to add to this Pull Request. The differents between god flag and No Fall Damage flag is; God: Have No Fall Damage disabled, and have PvP disabled at the same time, and No Fall Damage flag - You can disable No Fall Damage, but have PvP enabled at the same time. 
This could be useful for those server owners who have arenas, that you can jump down towards and fight. People may be getting sick of the issues, such as: I can't disable fall damage in my area and have PvP enabled at the same time, and people may also have issues with creating a high based arenas, such as: Arena spawn - Jump down to fight. Well, this could be triggered by fall damage, which for some reason, the god flag does have, but would be nice to have it during PvP as well. Which again, I thought it would've been added.  I decided to re-create a new flag, relating to god mode, but would be for one-solution only. - This also recreates the no fall damage sample, so if you want PvP enabled with no fall damage, then this flag is for you. Which is what I wanted to tell you in this PR, and hopefully, you'll merge it for everyone's use. 
Thanks.