### PR TITLE
Release 1.0.8 ready

### DIFF
--- a/src/genboy/Festival/Main.php
+++ b/src/genboy/Festival/Main.php
@@ -18,7 +18,7 @@
  *
  * Options in config.yml
  * language: en/nl, Msgtype: msg/title/tip/pop, Areadisplay: off/op/on, Msgdisplay: off/op/on
- * Flags: god, pvp, flight, edit, touch, mobs, animals, effects, msg, passage, drop, tnt, shoot, hunger, perms, falldamage, cmdmode
+ * Flags: god, pvp, flight, edit, touch, mobs, animals, effects, msg, passage, drop, tnt, fire, explode, shoot, hunger, perms, falldamage, cmdmode
  *
  */
 


### PR DESCRIPTION
Festival 1.0.8 Features & changes:
  - /fe lang <en/nl/..> - set  Festival language in config.yml
  - Edit flag includes No Farmland creation
  - Edit flag includes protect item in frame use
  - !NEW Fire flag includes No Fire from Flint & Steel and No lava 
  - !NEW TNT flag includes No TNT placing or tnt explosions 
  - !NEW Explode flag includes No entity explosions  
  - Areas floating title (/fe titles - Areadisplay option in config.yml)
  - Mobs flag prevent mobs from spawning in area
  - Animals flag prevent animals from spawning in area
  - Area messages display in chat with config option Msgtype 'msg' 
  - cmd flag: area event commands for ops or whitelisted players only 