### PR TITLE
compass options & whitelist bug fix

### DIFF
--- a/src/genboy/Festival/Festival.php
+++ b/src/genboy/Festival/Festival.php
@@ -18,6 +18,7 @@ use pocketmine\command\CommandSender;
 use pocketmine\command\ConsoleCommandSender;
 use pocketmine\entity\Entity;
 use pocketmine\entity\Item;
+use pocketmine\item\Item as ItemIdList;
 use pocketmine\block\Block;
 use pocketmine\entity\Human;
 use pocketmine\entity\object\ExperienceOrb;
@@ -1197,6 +1198,24 @@ class Festival extends PluginBase implements Listener{
         if( $itemheld ==  $this->config['options']['itemid'] && !isset( $this->players[ strtolower( $player->getName() ) ]["makearea"] ) ) {
             $this->form->openUI($player);
         }
+        // check compass to select direction
+        if($itemheld === ItemIdList::COMPASS){
+            $playerareas = [];
+            if( $player->isOp() || $player->hasPermission("festival") || $player->hasPermission("festival.access") ){
+                $playerareas = $this->areas;
+            }else{
+                foreach($this->areas as $area){
+                    if( $area->isWhitelisted( strtolower( $player->getName() )  ) ){
+                        $playerareas[] = $area;
+                    }
+                }
+            }
+            if( count( $playerareas ) > 0 ){
+                $player->sendMessage('Use compass to find an area');
+                $this->form->compassAreaForm( $player );
+            }
+        }
+
     }
 
     /** levelChange
@@ -2810,6 +2829,8 @@ class Festival extends PluginBase implements Listener{
                 unset( $this->inArea[$p] ); // remove player from inArea list
             }
         }
+
+        // to do styling
         if(count($ap) > 0 ){
             $l .=  "\n". TextFormat::GRAY . "  - ". Language::translate("players-in-area") .": " . TextFormat::GOLD . implode(", ", $ap );
         }
@@ -2923,18 +2944,6 @@ class Festival extends PluginBase implements Listener{
 		return;
     }
 
-	/** Save areas
-	 * @var obj area
-	 * @file areas.json
-
-	public function saveAreas() : void{
-		$areas = [];
-		foreach($this->areas as $area){
-			$areas[] = ["name" => $area->getName(), "desc" => $area->getDesc(), "priority" => $area->getPriority(), "flags" => $area->getFlags(), "pos1" => [$area->getFirstPosition()->getFloorX(), $area->getFirstPosition()->getFloorY(), $area->getFirstPosition()->getFloorZ()] , "pos2" => [$area->getSecondPosition()->getFloorX(), $area->getSecondPosition()->getFloorY(), $area->getSecondPosition()->getFloorZ()], "radius" => $area->getRadius(), "top" => $area->getTop(), "bottom" => $area->getBottom(), "level" => $area->getLevelName(), "whitelist" => $area->getWhitelist(), "commands" => $area->getCommands(), "events" => $area->getEvents()];
-		}
-		file_put_contents($this->getDataFolder() . "areas.json", json_encode($areas));
-	}
-*/
 
     /**  Festival Console Sign Flag for developers
      *   makes it easy to find Festival console output fast

--- a/src/genboy/Festival/FormUI.php
+++ b/src/genboy/Festival/FormUI.php
@@ -17,6 +17,8 @@ use pocketmine\plugin\PluginBase;
 use pocketmine\event\Listener;
 use pocketmine\utils\TextFormat;
 
+use pocketmine\network\mcpe\protocol\SetSpawnPositionPacket;
+
 class FormUI{
 
     private $plugin;
@@ -601,6 +603,7 @@ class FormUI{
                         }else{
                             $area->setWhitelisted($nm,false);
                         }
+                        $c++;
                     }
                     $this->areaWhitelistForm( $sender, false, Language::translate("ui-area-whitelist-saved") );
 
@@ -961,4 +964,96 @@ class FormUI{
         $form->addDropdown( Language::translate("ui-tp-to-area") , $selectlist );
         $form->sendToPlayer($sender);
     }
+
+    /** compassAreaForm
+     * @class formUI
+	 * @param Player $sender
+     */
+    public function compassAreaForm( Player $sender ) : void {
+        $form = new CustomForm( function ( Player $sender, ?array $data ) {
+            if( $data === null){
+                return;
+            }
+            //var_dump($data);
+            if( isset( $data[0] ) ){
+                $selectlist = array();
+                $currentlevel = strtolower( $sender->getPosition()->getLevel()->getName() );
+                foreach($this->plugin->areas as $area){
+                    if( $sender->isOp() || $sender->hasPermission("festival") || $sender->hasPermission("festival.access") || $area->isWhitelisted( strtolower( $sender->getName() ) ) ){
+                        if( $area->getLevelName() == $currentlevel ){
+                            $selectlist[] = $area->getName();
+                        }
+                    }
+                }
+                if( $data[0] == 0 ){
+
+                    $sender->sendMessage('Selected world spawnpoint' );
+                    $pk = new SetSpawnPositionPacket();
+                    $target = $sender->getLevel()->getSafeSpawn();
+                    $pk->x = $target->x;
+                    $pk->y = $target->y;
+                    $pk->z = $target->z;
+                    $pk->spawnType = SetSpawnPositionPacket::TYPE_WORLD_SPAWN;
+                    $pk->spawnForced = true;
+                    $sender->sendDataPacket($pk);
+
+                }else if(  $selectlist[ $data[0] - 1 ] ){
+
+                    $areaname = $selectlist[ $data[0] - 1 ];
+                    if( isset( $this->plugin->areas[ $areaname ] ) ){
+
+                        $area = $this->plugin->areas[ $areaname ];
+                        if( null !== $area->getRadius() && $area->getRadius() > 0 && null !== $area->getFirstPosition()  ){
+                            $cx = $area->getFirstPosition()->getX();
+                            $cy = $area->getFirstPosition()->getY();
+                            $cz = $area->getFirstPosition()->getZ();
+                        }else if( null !== $area->getFirstPosition() && null !== $area->getSecondPosition() ){
+                            $cx = $area->getSecondPosition()->getX() + ( ( $area->getFirstPosition()->getX() - $area->getSecondPosition()->getX() ) / 2 );
+                            $cy = $sender->getPosition()->getY();
+                            $cz = $area->getSecondPosition()->getZ() + ( ( $area->getFirstPosition()->getZ() - $area->getSecondPosition()->getZ() ) / 2 );
+                        }
+
+                        if( isset($cx) && isset($cy) && isset($cz) ){
+
+                            $sender->sendMessage('Selected '. $areaname ); // Server::getInstance()->dispatchCommand($sender, "fe tp ".$areaname );
+                            $pk = new SetSpawnPositionPacket();
+                            $pk->spawnType = SetSpawnPositionPacket::TYPE_WORLD_SPAWN;
+                            $pk->x = (int) $cx;
+                            $pk->y = (int) $cy;
+                            $pk->z = (int) $cz;
+                            $pk->spawnForced = false;
+                            $sender->dataPacket($pk);
+
+                        }else{
+
+                            $sender->sendMessage( 'Direction could be set on compass' );
+
+                        }
+
+                    }else{
+
+                         $sender->sendMessage( 'Selected area could not be found' );
+
+                    }
+                }
+            }
+        });
+
+        $form->setTitle( "Set compass direction" );
+        $selectlist = array();
+        $currentlevel = strtolower( $sender->getPosition()->getLevel()->getName() );
+        $selectlist[] = "World spawnpoint (default)";
+        foreach($this->plugin->areas as $area){
+            if( $sender->isOp() || $sender->hasPermission("festival") || $sender->hasPermission("festival.access") || $area->isWhitelisted( strtolower( $sender->getName() ) ) ){
+                if( $area->getLevelName() == $currentlevel ){
+                    $selectlist[] = $area->getName();
+                }
+            }
+        }
+        $form->addDropdown( "Set compass direction" , $selectlist ); // Language::translate("Set compass direction")
+        $form->sendToPlayer( $sender );
+    }
+
+
+
 }


### PR DESCRIPTION
- Fixing a whitelist bug (menu didn't save the whitelist correctly)

And a long awaited function is now slowly being implemented and ready for testing:
- Select compass direction. 
  This function pops up a selection menu to select either the original level spawnpoint or an area in the current level to set as the compass direction.